### PR TITLE
bugfix: ensure maximum key length reflects redis documentation

### DIFF
--- a/src/Redis.php
+++ b/src/Redis.php
@@ -502,6 +502,7 @@ class Redis extends AbstractAdapter implements
             $serializer        = $resourceMgr->getLibOption($options->getResourceId(), RedisResource::OPT_SERIALIZER);
             $redisVersion      = $resourceMgr->getMajorVersion($options->getResourceId());
             $minTtl            = version_compare($redisVersion, '2', '<') ? 0 : 1;
+            $maxKeyLength      = version_compare($redisVersion, '3', '<') ? 255 : 512000000;
             $supportedMetadata = $redisVersion >= 2 ? ['ttl'] : [];
 
             $this->capabilities = new Capabilities(
@@ -533,7 +534,7 @@ class Redis extends AbstractAdapter implements
                     'staticTtl'          => true,
                     'ttlPrecision'       => 1,
                     'useRequestTime'     => false,
-                    'maxKeyLength'       => 255,
+                    'maxKeyLength'       => $maxKeyLength,
                     'namespaceIsPrefix'  => true,
                 ]
             );


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Bugfix        | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

As we do not have evidence that redis less than v3 has support for keys with 512 MB (due to lack of docker image), we continue provide `255` as maximum key length.

Fixes #9