### PR TITLE
PHP 8.2: Remove dynamic property creation in unit test

### DIFF
--- a/test/integration/Laminas/RedisFromExtensionAsset.php
+++ b/test/integration/Laminas/RedisFromExtensionAsset.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Cache\Storage\Adapter\Laminas;
+
+use Redis;
+
+class RedisFromExtensionAsset extends Redis
+{
+    /**
+     * It seems that the extension creates and sets the `socket` property to `true` once the object is initialized.
+     * {@see \Laminas\Cache\Storage\Adapter\RedisResourceManager::setResource()}
+     * Since PHP 8.2 deprecates dynamic property creation, we are using this asset until the redis extension
+     * will provide this property.
+     */
+    public bool $socket = false;
+}

--- a/test/integration/Laminas/RedisTest.php
+++ b/test/integration/Laminas/RedisTest.php
@@ -392,7 +392,7 @@ final class RedisTest extends AbstractCommonAdapterTest
      */
     private function mockInitializedRedisResource()
     {
-        $redis         = $this->getMockBuilder(RedisResource::class)->getMock();
+        $redis         = $this->createMock(RedisFromExtensionAsset::class);
         $redis->socket = true;
         $redis->method('info')->willReturn(['redis_version' => '0.0.0-unknown']);
         return $redis;


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding documentation?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

Due to the changes made to PHP 8.2, creating dynamic properties is not allowed anymore. Once the `redis` extension catches up, we can remove the asset again.