### PR TITLE
Handle non-array return values for `RedisCluster#mget`

### DIFF
--- a/src/Exception/RedisRuntimeException.php
+++ b/src/Exception/RedisRuntimeException.php
@@ -13,6 +13,8 @@ use Throwable;
 
 final class RedisRuntimeException extends LaminasCacheRuntimeException
 {
+    private const INTERNAL_REDIS_ERROR = 'Something went wrong while interacting with redis cluster.';
+
     public static function fromClusterException(RedisClusterException $exception, RedisCluster $redis): self
     {
         $message = $redis->getLastError() ?? $exception->getMessage();
@@ -38,5 +40,16 @@ final class RedisRuntimeException extends LaminasCacheRuntimeException
         }
 
         return new self($message, $exception->getCode(), $exception);
+    }
+
+    public static function fromInternalRedisError(RedisCluster|Redis $redis): self
+    {
+        try {
+            $message = $redis->getLastError() ?? self::INTERNAL_REDIS_ERROR;
+        } catch (RedisException) {
+            $message = self::INTERNAL_REDIS_ERROR;
+        }
+
+        return new self($message);
     }
 }


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Bugfix        | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding documentation?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

As per https://github.com/phpredis/phpredis/blob/35a7cc094c6c264aa37738b074c4c54c4ca73b87/redis_cluster.stub.php#L621, the `RedisCluster#mget` method can return non-array values:
- `RedisCluster` in case we are within `multi` mode
- `false` in case there was an error which did not end up in an `RedisClusterException`

Fixes #74 