### PR TITLE
Add SSL context for RedisCluster connections

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
-        "ext-redis": "^5.0.2 || ^6.0",
+        "ext-redis": "^5.3.2 || ^6.0",
         "laminas/laminas-cache": "^3.10"
     },
     "provide": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "18eabbd1db8bc1ba904fad53c3ef3071",
+    "content-hash": "2bad8f0b0911d3df5ac703cd0701dd45",
     "packages": [
         {
             "name": "laminas/laminas-cache",
@@ -5554,7 +5554,7 @@
     "prefer-lowest": false,
     "platform": {
         "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
-        "ext-redis": "^5.0.2 || ^6.0"
+        "ext-redis": "^5.3.2 || ^6.0"
     },
     "platform-dev": [],
     "platform-overrides": {

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -139,6 +139,7 @@
       <code>setReadTimeout</code>
       <code>setSeeds</code>
       <code>setTimeout</code>
+      <code>setSslContext</code>
     </PossiblyUnusedMethod>
   </file>
   <file src="src/RedisOptions.php">

--- a/psalm.xml
+++ b/psalm.xml
@@ -50,15 +50,6 @@
                 <directory name="*"/>
             </errorLevel>
         </RedundantCastGivenDocblockType>
-        <!--
-            Psalm currently (<= 5.23.1) uses an outdated (phpredis < 5.3.2) constructor signature for the RedisCluster
-            class in the phpredis extension.
-        -->
-        <TooManyArguments>
-            <errorLevel type="suppress">
-                <referencedFunction name="RedisCluster::__construct"/>
-            </errorLevel>
-        </TooManyArguments>
     </issueHandlers>
     <plugins>
         <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>

--- a/psalm.xml
+++ b/psalm.xml
@@ -50,6 +50,15 @@
                 <directory name="*"/>
             </errorLevel>
         </RedundantCastGivenDocblockType>
+        <!--
+            Psalm currently (<= 5.23.1) uses an outdated (phpredis < 5.3.2) constructor signature for the RedisCluster
+            class in the phpredis extension.
+        -->
+        <TooManyArguments>
+            <errorLevel type="suppress">
+                <referencedFunction name="RedisCluster::__construct"/>
+            </errorLevel>
+        </TooManyArguments>
     </issueHandlers>
     <plugins>
         <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>

--- a/src/RedisClusterOptions.php
+++ b/src/RedisClusterOptions.php
@@ -7,6 +7,8 @@ namespace Laminas\Cache\Storage\Adapter;
 use Laminas\Cache\Exception\RuntimeException;
 use Laminas\Cache\Storage\Adapter\Exception\InvalidRedisClusterConfigurationException;
 
+use function is_array;
+
 final class RedisClusterOptions extends AdapterOptions
 {
     public const LIBRARY_OPTIONS = [
@@ -53,8 +55,8 @@ final class RedisClusterOptions extends AdapterOptions
 
     private string $password = '';
 
-    /** @psalm-var array<non-empty-string,mixed>|null */
-    private ?array $sslContext = null;
+    /** @psalm-var SslContext|null */
+    private ?SslContext $sslContext = null;
 
     /**
      * @param iterable|null|AdapterOptions $options
@@ -227,18 +229,23 @@ final class RedisClusterOptions extends AdapterOptions
     }
 
     /**
-     * @psalm-return array<non-empty-string,mixed>|null
+     * @psalm-return SslContext|null
      */
-    public function getSslContext(): ?array
+    public function getSslContext(): ?SslContext
     {
         return $this->sslContext;
     }
 
     /**
-     * @psalm-param array<non-empty-string,mixed>|null $sslContext
+     * @psalm-param array<non-empty-string,mixed>|SslContext|null $sslContext
      */
-    public function setSslContext(?array $sslContext): void
+    public function setSslContext(array|SslContext|null $sslContext): void
     {
+        if (is_array($sslContext)) {
+            $data       = $sslContext;
+            $sslContext = new SslContext();
+            $sslContext->exchangeArray($data);
+        }
         $this->sslContext = $sslContext;
     }
 }

--- a/src/RedisClusterOptions.php
+++ b/src/RedisClusterOptions.php
@@ -53,6 +53,8 @@ final class RedisClusterOptions extends AdapterOptions
 
     private string $password = '';
 
+    private array $sslContext = [];
+
     /**
      * @param iterable|null|AdapterOptions $options
      * @psalm-param iterable<string,mixed>|null|AdapterOptions $options
@@ -221,5 +223,15 @@ final class RedisClusterOptions extends AdapterOptions
     public function setPassword(string $password): void
     {
         $this->password = $password;
+    }
+
+    public function getSslContext(): array
+    {
+        return $this->sslContext;
+    }
+
+    public function setSslContext(array $sslContext): void
+    {
+        $this->sslContext = $sslContext;
     }
 }

--- a/src/RedisClusterOptions.php
+++ b/src/RedisClusterOptions.php
@@ -53,6 +53,7 @@ final class RedisClusterOptions extends AdapterOptions
 
     private string $password = '';
 
+    /** @psalm-var array<string,mixed> */
     private array $sslContext = [];
 
     /**
@@ -225,6 +226,9 @@ final class RedisClusterOptions extends AdapterOptions
         $this->password = $password;
     }
 
+    /**
+     * @psalm-return array<string,mixed>
+     */
     public function getSslContext(): array
     {
         return $this->sslContext;

--- a/src/RedisClusterOptions.php
+++ b/src/RedisClusterOptions.php
@@ -53,8 +53,8 @@ final class RedisClusterOptions extends AdapterOptions
 
     private string $password = '';
 
-    /** @psalm-var array<string,mixed> */
-    private array $sslContext = [];
+    /** @psalm-var array<non-empty-string,mixed>|null */
+    private ?array $sslContext = null;
 
     /**
      * @param iterable|null|AdapterOptions $options
@@ -227,14 +227,17 @@ final class RedisClusterOptions extends AdapterOptions
     }
 
     /**
-     * @psalm-return array<string,mixed>
+     * @psalm-return array<non-empty-string,mixed>|null
      */
-    public function getSslContext(): array
+    public function getSslContext(): ?array
     {
         return $this->sslContext;
     }
 
-    public function setSslContext(array $sslContext): void
+    /**
+     * @psalm-param array<non-empty-string,mixed>|null $sslContext
+     */
+    public function setSslContext(?array $sslContext): void
     {
         $this->sslContext = $sslContext;
     }

--- a/src/RedisClusterResourceManager.php
+++ b/src/RedisClusterResourceManager.php
@@ -98,7 +98,7 @@ final class RedisClusterResourceManager implements RedisClusterResourceManagerIn
             $options->getReadTimeout(),
             $options->isPersistent(),
             $password,
-            $options->getSslContext()
+            $options->getSslContext()?->getArrayCopy()
         );
     }
 
@@ -111,7 +111,7 @@ final class RedisClusterResourceManager implements RedisClusterResourceManagerIn
         float $fallbackReadTimeout,
         bool $persistent,
         string $fallbackPassword,
-        ?array $sslContext
+        ?SslContext $sslContext
     ): RedisClusterFromExtension {
         $options     = new RedisClusterOptionsFromIni();
         $seeds       = $options->getSeeds($name);
@@ -126,7 +126,7 @@ final class RedisClusterResourceManager implements RedisClusterResourceManagerIn
             $readTimeout,
             $persistent,
             $password,
-            $sslContext
+            $sslContext?->getArrayCopy()
         );
     }
 

--- a/src/RedisClusterResourceManager.php
+++ b/src/RedisClusterResourceManager.php
@@ -111,7 +111,7 @@ final class RedisClusterResourceManager implements RedisClusterResourceManagerIn
         float $fallbackReadTimeout,
         bool $persistent,
         string $fallbackPassword,
-        array $sslContext
+        ?array $sslContext
     ): RedisClusterFromExtension {
         $options     = new RedisClusterOptionsFromIni();
         $seeds       = $options->getSeeds($name);

--- a/src/RedisClusterResourceManager.php
+++ b/src/RedisClusterResourceManager.php
@@ -91,6 +91,12 @@ final class RedisClusterResourceManager implements RedisClusterResourceManagerIn
             $password = null;
         }
 
+        /**
+         * Psalm currently (<= 5.23.1) uses an outdated (phpredis < 5.3.2) constructor signature for the RedisCluster
+         * class in the phpredis extension.
+         *
+         * @psalm-suppress TooManyArguments https://github.com/vimeo/psalm/pull/10862
+         */
         return new RedisClusterFromExtension(
             null,
             $options->getSeeds(),
@@ -119,6 +125,12 @@ final class RedisClusterResourceManager implements RedisClusterResourceManagerIn
         $readTimeout = $options->getReadTimeout($name, $fallbackReadTimeout);
         $password    = $options->getPasswordByName($name, $fallbackPassword);
 
+        /**
+         * Psalm currently (<= 5.23.1) uses an outdated (phpredis < 5.3.2) constructor signature for the RedisCluster
+         * class in the phpredis extension.
+         *
+         * @psalm-suppress TooManyArguments https://github.com/vimeo/psalm/pull/10862
+         */
         return new RedisClusterFromExtension(
             null,
             $seeds,

--- a/src/RedisClusterResourceManager.php
+++ b/src/RedisClusterResourceManager.php
@@ -104,7 +104,7 @@ final class RedisClusterResourceManager implements RedisClusterResourceManagerIn
             $options->getReadTimeout(),
             $options->isPersistent(),
             $password,
-            $options->getSslContext()?->getArrayCopy()
+            $options->getSslContext()?->toSslContextArray()
         );
     }
 
@@ -138,7 +138,7 @@ final class RedisClusterResourceManager implements RedisClusterResourceManagerIn
             $readTimeout,
             $persistent,
             $password,
-            $sslContext?->getArrayCopy()
+            $sslContext?->toSslContextArray()
         );
     }
 

--- a/src/RedisClusterResourceManager.php
+++ b/src/RedisClusterResourceManager.php
@@ -81,7 +81,8 @@ final class RedisClusterResourceManager implements RedisClusterResourceManagerIn
                 $options->getTimeout(),
                 $options->getReadTimeout(),
                 $options->isPersistent(),
-                $options->getPassword()
+                $options->getPassword(),
+                $options->getSslContext()
             );
         }
 
@@ -96,7 +97,8 @@ final class RedisClusterResourceManager implements RedisClusterResourceManagerIn
             $options->getTimeout(),
             $options->getReadTimeout(),
             $options->isPersistent(),
-            $password
+            $password,
+            $options->getSslContext()
         );
     }
 
@@ -108,7 +110,8 @@ final class RedisClusterResourceManager implements RedisClusterResourceManagerIn
         float $fallbackTimeout,
         float $fallbackReadTimeout,
         bool $persistent,
-        string $fallbackPassword
+        string $fallbackPassword,
+        array $sslContext
     ): RedisClusterFromExtension {
         $options     = new RedisClusterOptionsFromIni();
         $seeds       = $options->getSeeds($name);
@@ -122,7 +125,8 @@ final class RedisClusterResourceManager implements RedisClusterResourceManagerIn
             $timeout,
             $readTimeout,
             $persistent,
-            $password
+            $password,
+            $sslContext
         );
     }
 

--- a/src/SslContext.php
+++ b/src/SslContext.php
@@ -4,197 +4,217 @@ declare(strict_types=1);
 
 namespace Laminas\Cache\Storage\Adapter;
 
-use InvalidArgumentException;
-use Laminas\Stdlib\ArraySerializableInterface;
-use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
-
-use function boolval;
-use function get_object_vars;
-use function property_exists;
-use function sprintf;
-
-use const OPENSSL_DEFAULT_STREAM_CIPHERS;
-use const OPENSSL_TLSEXT_SERVER_NAME;
+use SensitiveParameter;
 
 /**
  * Class containing the SSL context options in its fields.
  *
  * @link https://www.php.net/manual/en/context.ssl.php
+ *
+ * @psalm-type SSLContextArrayShape = array{
+ *     peer_name?: non-empty-string,
+ *     verify_peer?: bool,
+ *     verify_peer_name?: bool,
+ *     allow_self_signed?: bool,
+ *     cafile?: non-empty-string,
+ *     capath?: non-empty-string,
+ *     local_cert?: non-empty-string,
+ *     local_pk?: non-empty-string,
+ *     passphrase?: non-empty-string,
+ *     verify_depth?: non-negative-int,
+ *     ciphers?: non-empty-string,
+ *     SNI_enabled?: bool,
+ *     disable_compression?: bool,
+ *     peer_fingerprint?: non-empty-string|array<non-empty-string,non-empty-string>,
+ *     security_level?: non-negative-int
+ * }
  */
-final class SslContext implements ArraySerializableInterface
+final class SslContext
 {
     /**
-     * Peer name to be used.
-     * If this value is not set, then the name is guessed based on the hostname used when opening the stream.
+     * @param non-empty-string|null $expectedPeerName
+     * @param non-empty-string|null $certificateAuthorityFile
+     * @param non-empty-string|null $certificateAuthorityPath
+     * @param non-empty-string|null $localCertificatePath
+     * @param non-empty-string|null $localPrivateKeyPath
+     * @param non-empty-string|null $passphrase
+     * @param non-negative-int|null $verifyDepth
+     * @param non-empty-string|null $ciphers
+     * @param non-empty-string|array<non-empty-string,non-empty-string>|null $peerFingerprint
+     * @param non-negative-int|null $securityLevel
      */
-    private ?string $peerName;
-
-    /**
-     * Require verification of SSL certificate used.
-     */
-    private bool $verifyPeer;
-
-    /**
-     * Require verification of peer name.
-     */
-    private bool $verifyPeerName;
-
-    /**
-     * Allow self-signed certificates. Requires verifyPeer.
-     */
-    private bool $allowSelfSigned;
-
-    /**
-     * Location of Certificate Authority file on local filesystem which should be used with the verifyPeer
-     * context option to authenticate the identity of the remote peer.
-     */
-    private ?string $cafile;
-
-    /**
-     * If cafile is not specified or if the certificate is not found there, the directory pointed to by capath is
-     * searched for a suitable certificate. capath must be a correctly hashed certificate directory.
-     */
-    private ?string $capath;
-
-    /**
-     * Path to local certificate file on filesystem. It must be a PEM encoded file which contains your certificate and
-     * private key. It can optionally contain the certificate chain of issuers.
-     * The private key also may be contained in a separate file specified by localPk.
-     */
-    private ?string $localCert;
-
-    /**
-     * Path to local private key file on filesystem in case of separate files for certificate (localCert)
-     * and private key.
-     */
-    private ?string $localPk;
-
-    /**
-     * Passphrase with which your localCert file was encoded.
-     */
-    private ?string $passphrase;
-
-    /**
-     * Abort if the certificate chain is too deep.
-     * If not set, defaults to no verification.
-     */
-    private ?int $verifyDepth;
-
-    /**
-     * Sets the list of available ciphers. The format of the string is described in
-     * https://www.openssl.org/docs/manmaster/man1/ciphers.html#CIPHER-LIST-FORMAT
-     */
-    private string $ciphers;
-
-    /**
-     * If set to true server name indication will be enabled. Enabling SNI allows multiple certificates on the same
-     * IP address.
-     * If not set, will automatically be enabled if SNI support is available.
-     */
-    private ?bool $sniEnabled;
-
-    /**
-     * If set, disable TLS compression. This can help mitigate the CRIME attack vector.
-     */
-    private bool $disableCompression;
-
-    /**
-     * Aborts when the remote certificate digest doesn't match the specified hash.
-     *
-     * When a string is used, the length will determine which hashing algorithm is applied,
-     * either "md5" (32) or "sha1" (40).
-     *
-     * When an array is used, the keys indicate the hashing algorithm name and each corresponding
-     * value is the expected digest.
-     */
-    private string|array|null $peerFingerprint;
-
-    /**
-     * Sets the security level. If not specified the library default security level is used. The security levels are
-     * described in https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_get_security_level.html.
-     */
-    private ?int $securityLevel;
-
     public function __construct(
-        ?string $peerName = null,
-        bool $verifyPeer = true,
-        bool $verifyPeerName = true,
-        bool $allowSelfSigned = false,
-        ?string $cafile = null,
-        ?string $capath = null,
-        ?string $localCert = null,
-        ?string $localPk = null,
-        ?string $passphrase = null,
-        ?int $verifyDepth = null,
-        string $ciphers = OPENSSL_DEFAULT_STREAM_CIPHERS,
-        ?bool $sniEnabled = null,
-        bool $disableCompression = true,
-        array|string|null $peerFingerprint = null,
-        ?int $securityLevel = null
+        /**
+         * Peer name to be used.
+         * If this value is not set, then the name is guessed based on the hostname used when opening the stream.
+         */
+        public readonly ?string $expectedPeerName = null,
+        /**
+         * Require verification of SSL certificate used.
+         */
+        public readonly ?bool $verifyPeer = null,
+        /**
+         * Require verification of peer name.
+         */
+        public readonly ?bool $verifyPeerName = null,
+        /**
+         * Allow self-signed certificates. Requires verifyPeer.
+         */
+        public readonly ?bool $allowSelfSignedCertificates = null,
+        /**
+         * Location of Certificate Authority file on local filesystem which should be used with the verifyPeer
+         * context option to authenticate the identity of the remote peer.
+         */
+        public readonly ?string $certificateAuthorityFile = null,
+        /**
+         * If cafile is not specified or if the certificate is not found there, the directory pointed to by capath is
+         * searched for a suitable certificate. capath must be a correctly hashed certificate directory.
+         */
+        public readonly ?string $certificateAuthorityPath = null,
+        /**
+         * Path to local certificate file on filesystem. It must be a PEM encoded file which contains your certificate
+         * and private key. It can optionally contain the certificate chain of issuers.
+         * The private key also may be contained in a separate file specified by localPk.
+         */
+        public readonly ?string $localCertificatePath = null,
+        /**
+         * Path to local private key file on filesystem in case of separate files for certificate (localCert)
+         * and private key.
+         */
+        public readonly ?string $localPrivateKeyPath = null,
+        /**
+         * Passphrase with which your localCert file was encoded.
+         */
+        #[SensitiveParameter]
+        public readonly ?string $passphrase = null,
+        /**
+         * Abort if the certificate chain is too deep.
+         * If not set, defaults to no verification.
+         */
+        public readonly ?int $verifyDepth = null,
+        /**
+         * Sets the list of available ciphers. The format of the string is described in
+         * https://www.openssl.org/docs/manmaster/man1/ciphers.html#CIPHER-LIST-FORMAT
+         */
+        public readonly ?string $ciphers = null,
+        /**
+         * If set to true server name indication will be enabled. Enabling SNI allows multiple certificates on the same
+         * IP address.
+         * If not set, will automatically be enabled if SNI support is available.
+         */
+        public readonly ?bool $serverNameIndicationEnabled = null,
+        /**
+         * If set, disable TLS compression. This can help mitigate the CRIME attack vector.
+         */
+        public readonly ?bool $disableCompression = null,
+        /**
+         * Aborts when the remote certificate digest doesn't match the specified hash.
+         *
+         * When a string is used, the length will determine which hashing algorithm is applied,
+         * either "md5" (32) or "sha1" (40).
+         *
+         * When an array is used, the keys indicate the hashing algorithm name and each corresponding
+         * value is the expected digest.
+         */
+        public readonly array|string|null $peerFingerprint = null,
+        /**
+         * Sets the security level. If not specified the library default security level is used. The security levels are
+         * described in https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_get_security_level.html.
+         */
+        public readonly ?int $securityLevel = null,
     ) {
-        $this->peerName           = $peerName;
-        $this->verifyPeer         = $verifyPeer;
-        $this->verifyPeerName     = $verifyPeerName;
-        $this->allowSelfSigned    = $allowSelfSigned;
-        $this->cafile             = $cafile;
-        $this->capath             = $capath;
-        $this->localCert          = $localCert;
-        $this->localPk            = $localPk;
-        $this->passphrase         = $passphrase;
-        $this->verifyDepth        = $verifyDepth;
-        $this->ciphers            = $ciphers;
-        $this->sniEnabled         = $sniEnabled;
-        $this->disableCompression = $disableCompression;
-        $this->peerFingerprint    = $peerFingerprint;
-        $this->securityLevel      = $securityLevel;
-        if ($sniEnabled === null) {
-            $this->sniEnabled = boolval(OPENSSL_TLSEXT_SERVER_NAME);
-        }
     }
 
-    public function exchangeArray(array $array): void
+    /**
+     * @param SSLContextArrayShape $context
+     */
+    public static function fromSslContextArray(array $context): self
     {
-        foreach ($array as $key => $value) {
-            $property = $this->mapArrayKeyToPropertyName($key);
-            if (! property_exists($this, $property)) {
-                throw new InvalidArgumentException(
-                    sprintf(
-                        '%s does not contain the property "%s" corresponding to the array key "%s"',
-                        self::class,
-                        $property,
-                        $key
-                    )
-                );
-            }
-            $this->$property = $value;
-        }
+        return new self(
+            $context['peer_name'] ?? null,
+            $context['verify_peer'] ?? null,
+            $context['verify_peer_name'] ?? null,
+            $context['allow_self_signed'] ?? null,
+            $context['cafile'] ?? null,
+            $context['capath'] ?? null,
+            $context['local_cert'] ?? null,
+            $context['local_pk'] ?? null,
+            $context['passphrase'] ?? null,
+            $context['verify_depth'] ?? null,
+            $context['ciphers'] ?? null,
+            $context['SNI_enabled'] ?? null,
+            $context['disable_compression'] ?? null,
+            $context['peer_fingerprint'] ?? null,
+            $context['security_level'] ?? null,
+        );
     }
 
-    public function getArrayCopy(): array
+    /**
+     * @return SSLContextArrayShape
+     */
+    public function toSslContextArray(): array
     {
-        $array = [];
-        foreach (get_object_vars($this) as $property => $value) {
-            if ($value !== null) {
-                $key         = $this->mapPropertyNameToArrayKey($property);
-                $array[$key] = $value;
-            }
+        $context = [];
+        if ($this->expectedPeerName !== null) {
+            $context['peer_name'] = $this->expectedPeerName;
         }
-        return $array;
-    }
 
-    private function mapArrayKeyToPropertyName(string $key): string
-    {
-        if ($key === 'SNI_enabled') {
-            return 'sniEnabled';
+        if ($this->verifyPeer !== null) {
+            $context['verify_peer'] = $this->verifyPeer;
         }
-        return (new CamelCaseToSnakeCaseNameConverter())->denormalize($key);
-    }
 
-    private function mapPropertyNameToArrayKey(string $property): string
-    {
-        if ($property === 'sniEnabled') {
-            return 'SNI_enabled';
+        if ($this->verifyPeerName !== null) {
+            $context['verify_peer_name'] = $this->verifyPeerName;
         }
-        return (new CamelCaseToSnakeCaseNameConverter())->normalize($property);
+
+        if ($this->allowSelfSignedCertificates !== null) {
+            $context['allow_self_signed'] = $this->allowSelfSignedCertificates;
+        }
+
+        if ($this->certificateAuthorityFile !== null) {
+            $context['cafile'] = $this->certificateAuthorityFile;
+        }
+
+        if ($this->certificateAuthorityPath !== null) {
+            $context['capath'] = $this->certificateAuthorityPath;
+        }
+
+        if ($this->localCertificatePath !== null) {
+            $context['local_cert'] = $this->localCertificatePath;
+        }
+
+        if ($this->localPrivateKeyPath !== null) {
+            $context['local_pk'] = $this->localPrivateKeyPath;
+        }
+
+        if ($this->passphrase !== null) {
+            $context['passphrase'] = $this->passphrase;
+        }
+
+        if ($this->verifyDepth !== null) {
+            $context['verify_depth'] = $this->verifyDepth;
+        }
+
+        if ($this->ciphers !== null) {
+            $context['ciphers'] = $this->ciphers;
+        }
+
+        if ($this->serverNameIndicationEnabled !== null) {
+            $context['SNI_enabled'] = $this->serverNameIndicationEnabled;
+        }
+
+        if ($this->disableCompression !== null) {
+            $context['disable_compression'] = $this->disableCompression;
+        }
+
+        if ($this->peerFingerprint !== null) {
+            $context['peer_fingerprint'] = $this->peerFingerprint;
+        }
+
+        if ($this->securityLevel !== null) {
+            $context['security_level'] = $this->securityLevel;
+        }
+
+        return $context;
     }
 }

--- a/src/SslContext.php
+++ b/src/SslContext.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\Cache\Storage\Adapter;
+
+use InvalidArgumentException;
+use Laminas\Stdlib\ArraySerializableInterface;
+use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
+
+use function boolval;
+use function get_object_vars;
+use function property_exists;
+use function sprintf;
+
+use const OPENSSL_DEFAULT_STREAM_CIPHERS;
+use const OPENSSL_TLSEXT_SERVER_NAME;
+
+/**
+ * Class containing the SSL context options in its fields.
+ *
+ * @link https://www.php.net/manual/en/context.ssl.php
+ */
+final class SslContext implements ArraySerializableInterface
+{
+    /**
+     * Peer name to be used.
+     * If this value is not set, then the name is guessed based on the hostname used when opening the stream.
+     */
+    private ?string $peerName;
+
+    /**
+     * Require verification of SSL certificate used.
+     */
+    private bool $verifyPeer;
+
+    /**
+     * Require verification of peer name.
+     */
+    private bool $verifyPeerName;
+
+    /**
+     * Allow self-signed certificates. Requires verifyPeer.
+     */
+    private bool $allowSelfSigned;
+
+    /**
+     * Location of Certificate Authority file on local filesystem which should be used with the verifyPeer
+     * context option to authenticate the identity of the remote peer.
+     */
+    private ?string $cafile;
+
+    /**
+     * If cafile is not specified or if the certificate is not found there, the directory pointed to by capath is
+     * searched for a suitable certificate. capath must be a correctly hashed certificate directory.
+     */
+    private ?string $capath;
+
+    /**
+     * Path to local certificate file on filesystem. It must be a PEM encoded file which contains your certificate and
+     * private key. It can optionally contain the certificate chain of issuers.
+     * The private key also may be contained in a separate file specified by localPk.
+     */
+    private ?string $localCert;
+
+    /**
+     * Path to local private key file on filesystem in case of separate files for certificate (localCert)
+     * and private key.
+     */
+    private ?string $localPk;
+
+    /**
+     * Passphrase with which your localCert file was encoded.
+     */
+    private ?string $passphrase;
+
+    /**
+     * Abort if the certificate chain is too deep.
+     * If not set, defaults to no verification.
+     */
+    private ?int $verifyDepth;
+
+    /**
+     * Sets the list of available ciphers. The format of the string is described in
+     * https://www.openssl.org/docs/manmaster/man1/ciphers.html#CIPHER-LIST-FORMAT
+     */
+    private string $ciphers;
+
+    /**
+     * If set to true server name indication will be enabled. Enabling SNI allows multiple certificates on the same
+     * IP address.
+     * If not set, will automatically be enabled if SNI support is available.
+     */
+    private ?bool $sniEnabled;
+
+    /**
+     * If set, disable TLS compression. This can help mitigate the CRIME attack vector.
+     */
+    private bool $disableCompression;
+
+    /**
+     * Aborts when the remote certificate digest doesn't match the specified hash.
+     *
+     * When a string is used, the length will determine which hashing algorithm is applied,
+     * either "md5" (32) or "sha1" (40).
+     *
+     * When an array is used, the keys indicate the hashing algorithm name and each corresponding
+     * value is the expected digest.
+     */
+    private string|array|null $peerFingerprint;
+
+    /**
+     * Sets the security level. If not specified the library default security level is used. The security levels are
+     * described in https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_get_security_level.html.
+     */
+    private ?int $securityLevel;
+
+    public function __construct(
+        ?string $peerName = null,
+        bool $verifyPeer = true,
+        bool $verifyPeerName = true,
+        bool $allowSelfSigned = false,
+        ?string $cafile = null,
+        ?string $capath = null,
+        ?string $localCert = null,
+        ?string $localPk = null,
+        ?string $passphrase = null,
+        ?int $verifyDepth = null,
+        string $ciphers = OPENSSL_DEFAULT_STREAM_CIPHERS,
+        ?bool $sniEnabled = null,
+        bool $disableCompression = true,
+        array|string|null $peerFingerprint = null,
+        ?int $securityLevel = null
+    ) {
+        $this->peerName           = $peerName;
+        $this->verifyPeer         = $verifyPeer;
+        $this->verifyPeerName     = $verifyPeerName;
+        $this->allowSelfSigned    = $allowSelfSigned;
+        $this->cafile             = $cafile;
+        $this->capath             = $capath;
+        $this->localCert          = $localCert;
+        $this->localPk            = $localPk;
+        $this->passphrase         = $passphrase;
+        $this->verifyDepth        = $verifyDepth;
+        $this->ciphers            = $ciphers;
+        $this->sniEnabled         = $sniEnabled;
+        $this->disableCompression = $disableCompression;
+        $this->peerFingerprint    = $peerFingerprint;
+        $this->securityLevel      = $securityLevel;
+        if ($sniEnabled === null) {
+            $this->sniEnabled = boolval(OPENSSL_TLSEXT_SERVER_NAME);
+        }
+    }
+
+    public function exchangeArray(array $array): void
+    {
+        foreach ($array as $key => $value) {
+            $property = $this->mapArrayKeyToPropertyName($key);
+            if (! property_exists($this, $property)) {
+                throw new InvalidArgumentException(
+                    sprintf(
+                        '%s does not contain the property "%s" corresponding to the array key "%s"',
+                        self::class,
+                        $property,
+                        $key
+                    )
+                );
+            }
+            $this->$property = $value;
+        }
+    }
+
+    public function getArrayCopy(): array
+    {
+        $array = [];
+        foreach (get_object_vars($this) as $property => $value) {
+            if ($value !== null) {
+                $key         = $this->mapPropertyNameToArrayKey($property);
+                $array[$key] = $value;
+            }
+        }
+        return $array;
+    }
+
+    private function mapArrayKeyToPropertyName(string $key): string
+    {
+        if ($key === 'SNI_enabled') {
+            return 'sniEnabled';
+        }
+        return (new CamelCaseToSnakeCaseNameConverter())->denormalize($key);
+    }
+
+    private function mapPropertyNameToArrayKey(string $property): string
+    {
+        if ($property === 'sniEnabled') {
+            return 'SNI_enabled';
+        }
+        return (new CamelCaseToSnakeCaseNameConverter())->normalize($property);
+    }
+}

--- a/test/unit/RedisClusterOptionsTest.php
+++ b/test/unit/RedisClusterOptionsTest.php
@@ -34,11 +34,13 @@ final class RedisClusterOptionsTest extends AbstractAdapterOptionsTest
     {
         $options = new RedisClusterOptions([
             'name'        => 'foo',
-            'ssl_context' => new SslContext(localCert: '/path/to/localcert'),
+            'ssl_context' => new SslContext(localCertificatePath: '/path/to/localcert'),
         ]);
 
-        $this->assertEquals('foo', $options->getName());
-        $this->assertEquals(new SslContext(localCert: '/path/to/localcert'), $options->getSslContext());
+        self::assertEquals('foo', $options->getName());
+        $sslContext = $options->getSslContext();
+        self::assertNotNull($sslContext);
+        self::assertSame('/path/to/localcert', $sslContext->localCertificatePath);
     }
 
     public function testCanHandleOptionsWithSslContextArray(): void
@@ -48,8 +50,10 @@ final class RedisClusterOptionsTest extends AbstractAdapterOptionsTest
             'ssl_context' => ['local_cert' => '/path/to/localcert'],
         ]);
 
-        $this->assertEquals('foo', $options->getName());
-        $this->assertEquals(new SslContext(localCert: '/path/to/localcert'), $options->getSslContext());
+        self::assertEquals('foo', $options->getName());
+        $sslContext = $options->getSslContext();
+        self::assertNotNull($sslContext);
+        self::assertSame('/path/to/localcert', $sslContext->localCertificatePath);
     }
 
     public function testCanHandleOptionsWithNodename(): void

--- a/test/unit/RedisClusterOptionsTest.php
+++ b/test/unit/RedisClusterOptionsTest.php
@@ -9,6 +9,7 @@ use InvalidArgumentException;
 use Laminas\Cache\Storage\Adapter\AdapterOptions;
 use Laminas\Cache\Storage\Adapter\Exception\InvalidRedisClusterConfigurationException;
 use Laminas\Cache\Storage\Adapter\RedisClusterOptions;
+use Laminas\Cache\Storage\Adapter\SslContext;
 use Redis as RedisFromExtension;
 use ReflectionClass;
 
@@ -29,6 +30,28 @@ final class RedisClusterOptionsTest extends AbstractAdapterOptionsTest
         return new RedisClusterOptions(['seeds' => ['localhost']]);
     }
 
+    public function testCanHandleOptionsWithSslContextObject(): void
+    {
+        $options = new RedisClusterOptions([
+            'name'        => 'foo',
+            'ssl_context' => new SslContext(localCert: '/path/to/localcert'),
+        ]);
+
+        $this->assertEquals('foo', $options->getName());
+        $this->assertEquals(new SslContext(localCert: '/path/to/localcert'), $options->getSslContext());
+    }
+
+    public function testCanHandleOptionsWithSslContextArray(): void
+    {
+        $options = new RedisClusterOptions([
+            'name'        => 'foo',
+            'ssl_context' => ['local_cert' => '/path/to/localcert'],
+        ]);
+
+        $this->assertEquals('foo', $options->getName());
+        $this->assertEquals(new SslContext(localCert: '/path/to/localcert'), $options->getSslContext());
+    }
+
     public function testCanHandleOptionsWithNodename(): void
     {
         $options = new RedisClusterOptions([
@@ -38,7 +61,6 @@ final class RedisClusterOptionsTest extends AbstractAdapterOptionsTest
             'persistent'    => false,
             'redis_version' => '1.0',
             'password'      => 'secret',
-            'ssl_context'   => ['verify_peer' => false],
         ]);
 
         $this->assertEquals('foo', $options->getName());
@@ -47,7 +69,6 @@ final class RedisClusterOptionsTest extends AbstractAdapterOptionsTest
         $this->assertEquals(false, $options->isPersistent());
         $this->assertEquals('1.0', $options->getRedisVersion());
         $this->assertEquals('secret', $options->getPassword());
-        $this->assertEquals(['verify_peer' => false], $options->getSslContext());
     }
 
     public function testCanHandleOptionsWithSeeds(): void
@@ -59,7 +80,6 @@ final class RedisClusterOptionsTest extends AbstractAdapterOptionsTest
             'persistent'    => false,
             'redis_version' => '1.0',
             'password'      => 'secret',
-            'ssl_context'   => ['verify_peer' => false],
         ]);
 
         $this->assertEquals(['localhost:1234'], $options->getSeeds());
@@ -68,7 +88,6 @@ final class RedisClusterOptionsTest extends AbstractAdapterOptionsTest
         $this->assertEquals(false, $options->isPersistent());
         $this->assertEquals('1.0', $options->getRedisVersion());
         $this->assertEquals('secret', $options->getPassword());
-        $this->assertEquals(['verify_peer' => false], $options->getSslContext());
     }
 
     public function testWillDetectSeedsAndNodenameConfiguration(): void

--- a/test/unit/RedisClusterOptionsTest.php
+++ b/test/unit/RedisClusterOptionsTest.php
@@ -38,6 +38,7 @@ final class RedisClusterOptionsTest extends AbstractAdapterOptionsTest
             'persistent'    => false,
             'redis_version' => '1.0',
             'password'      => 'secret',
+            'ssl_context'   => ['verify_peer' => false],
         ]);
 
         $this->assertEquals('foo', $options->getName());
@@ -46,6 +47,7 @@ final class RedisClusterOptionsTest extends AbstractAdapterOptionsTest
         $this->assertEquals(false, $options->isPersistent());
         $this->assertEquals('1.0', $options->getRedisVersion());
         $this->assertEquals('secret', $options->getPassword());
+        $this->assertEquals(['verify_peer' => false], $options->getSslContext());
     }
 
     public function testCanHandleOptionsWithSeeds(): void
@@ -57,6 +59,7 @@ final class RedisClusterOptionsTest extends AbstractAdapterOptionsTest
             'persistent'    => false,
             'redis_version' => '1.0',
             'password'      => 'secret',
+            'ssl_context'   => ['verify_peer' => false],
         ]);
 
         $this->assertEquals(['localhost:1234'], $options->getSeeds());
@@ -65,6 +68,7 @@ final class RedisClusterOptionsTest extends AbstractAdapterOptionsTest
         $this->assertEquals(false, $options->isPersistent());
         $this->assertEquals('1.0', $options->getRedisVersion());
         $this->assertEquals('secret', $options->getPassword());
+        $this->assertEquals(['verify_peer' => false], $options->getSslContext());
     }
 
     public function testWillDetectSeedsAndNodenameConfiguration(): void

--- a/test/unit/SslContextTest.php
+++ b/test/unit/SslContextTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Cache\Storage\Adapter;
+
+use InvalidArgumentException;
+use Laminas\Cache\Storage\Adapter\SslContext;
+use PHPUnit\Framework\TestCase;
+use TypeError;
+
+use function boolval;
+
+use const OPENSSL_DEFAULT_STREAM_CIPHERS;
+use const OPENSSL_TLSEXT_SERVER_NAME;
+
+final class SslContextTest extends TestCase
+{
+    private SslContext $correspondingSslContextObject;
+    private array $correspondingSslContextArray;
+
+    protected function setUp(): void
+    {
+        $this->correspondingSslContextObject = new SslContext(
+            peerName: 'some peer name',
+            allowSelfSigned: true,
+            verifyDepth: 10,
+            peerFingerprint: ['md5' => 'some fingerprint']
+        );
+
+        $this->correspondingSslContextArray = [
+            'peer_name'           => 'some peer name',
+            'verify_peer'         => true,
+            'verify_peer_name'    => true,
+            'allow_self_signed'   => true,
+            'verify_depth'        => 10,
+            'ciphers'             => OPENSSL_DEFAULT_STREAM_CIPHERS,
+            'SNI_enabled'         => boolval(OPENSSL_TLSEXT_SERVER_NAME),
+            'disable_compression' => true,
+            'peer_fingerprint'    => ['md5' => 'some fingerprint'],
+        ];
+    }
+
+    public function testExchangeArraySetsPropertiesCorrectly(): void
+    {
+        $sslContextObject = new SslContext();
+        $sslContextObject->exchangeArray($this->correspondingSslContextArray);
+
+        $this->assertEquals(
+            $this->correspondingSslContextObject,
+            $sslContextObject
+        );
+    }
+
+    public function testGetArrayCopyReturnsAnArrayWithPropertyValues()
+    {
+        $sslContextArray = $this->correspondingSslContextObject->getArrayCopy();
+
+        $this->assertEquals($this->correspondingSslContextArray, $sslContextArray);
+    }
+
+    public function testExchangeArrayThrowsExceptionWhenProvidingInvalidKeyName(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches(
+            '/does not contain the property "someInvalidKey" corresponding to the array key "some_invalid_key"/'
+        );
+
+        $sslContextObject = new SslContext();
+        $sslContextObject->exchangeArray(['some_invalid_key' => true]);
+    }
+
+    public function testExchangeArrayThrowsExceptionWhenProvidingInvalidValueType(): void
+    {
+        $this->expectException(TypeError::class);
+        $this->expectExceptionMessageMatches(
+            '/\$verifyPeer of type bool/'
+        );
+
+        $sslContextObject = new SslContext();
+        $sslContextObject->exchangeArray(['verify_peer' => 'invalid type']);
+    }
+}


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description
This small feature allows to pass an [sslContext](https://www.php.net/manual/en/context.ssl.php) to the [RedisCluster constructor](https://github.com/phpredis/phpredis/blob/develop/cluster.md) from the phpredis extension.

Without this feature, one could not connect to a cluster using TLS. Now when specifying the correct protocol for the seed nodes (e.g.: 'seeds' => ['tls://nodeId-01.xxx:6379', 'tls://nodeId-02.xxx:6379']) and passing an sslContext one can connect to a cluster using TLS .

One can pass an empty array for the sslContext, but also explicitly specify non-default options for the TLS connection. For a full list of ssl context options see: https://www.php.net/manual/en/context.ssl.php.

This for example enables one to connect to an AWS elasticache redis cluster with in-transit encryption set to required due to security reasons.


<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding documentation?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
