### PR TITLE
Fix: touch without TTL

### DIFF
--- a/src/Redis.php
+++ b/src/Redis.php
@@ -211,7 +211,7 @@ final class Redis extends AbstractMetadataCapableAdapter implements
         $ttl     = $options->getTtl();
 
         try {
-            if ($ttl) {
+            if ($ttl > 0) {
                 if ($this->getCapabilities()->ttlSupported === false) {
                     throw new Exception\UnsupportedMethodCallException(
                         'To use ttl you need redis-server version >= 2.0.0',
@@ -323,7 +323,11 @@ final class Redis extends AbstractMetadataCapableAdapter implements
         $redis = $this->getRedisResource();
         try {
             $ttl = $this->getOptions()->getTtl();
-            return (bool) $redis->expire($this->createNamespacedKey($normalizedKey), (int) $ttl);
+            if ($ttl > 0) {
+                return (bool) $redis->expire($this->createNamespacedKey($normalizedKey), (int) $ttl);
+            } else {
+                return (bool) $redis->touch($this->createNamespacedKey($normalizedKey));
+            }
         } catch (RedisFromExtensionException $exception) {
             throw RedisRuntimeException::fromRedisException($exception, $redis);
         }

--- a/test/integration/Laminas/RedisTest.php
+++ b/test/integration/Laminas/RedisTest.php
@@ -181,9 +181,23 @@ final class RedisTest extends AbstractCommonAdapterTest
         self::assertNotNull($metadata);
         self::assertEquals(Redis\Metadata::TTL_UNLIMITED, $metadata->remainingTimeToLive);
 
+        // touch with zero TTL should keep the record
+        self::assertTrue($this->storage->touchItem($key));
+        $this->assertTrue($this->storage->hasItem($key));
+        $metadata = $this->storage->getMetadata($key);
+        self::assertNotNull($metadata);
+        self::assertEquals(Redis\Metadata::TTL_UNLIMITED, $metadata->remainingTimeToLive);
+
         // touch with a specific TTL will add this TTL
         $ttl = 1000;
         $this->storage->getOptions()->setTtl($ttl);
+        self::assertTrue($this->storage->touchItem($key));
+        $metadata = $this->storage->getMetadata($key);
+        self::assertNotNull($metadata);
+        self::assertEquals($ttl, $metadata->remainingTimeToLive);
+
+        // touch with zero default TTL should keep record original TTL
+        $this->storage->getOptions()->setTtl(0);
         self::assertTrue($this->storage->touchItem($key));
         $metadata = $this->storage->getMetadata($key);
         self::assertNotNull($metadata);


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Current code for `Redis::internalTouchItem()` is done by using EXPIRE command. But if there are no TTL specified in options, then TTL is zero. And EXPIRE with zero TTL means "delete this record". That's obviously not that `touch()` is intended for.

There are explicit checks for zero TTL in other places of library, but somehow not here. This PR is aimed to fix this issue, since there are dedicated TOUCH command in Redis, and record could had explicitly set, non-default TTL.