### PR TITLE
Optimization: do not explicitly select database 0, since its already selected by default

### DIFF
--- a/src/RedisResourceManager.php
+++ b/src/RedisResourceManager.php
@@ -68,7 +68,10 @@ final class RedisResourceManager implements RedisResourceManagerInterface
         ];
 
         $resource = new RedisFromExtension(array_filter($resourceOptions, fn (mixed $value) => $value !== null));
-        $resource->select($options->getDatabase());
+        $db       = $options->getDatabase();
+        if (0 !== $db) {
+            $resource->select($db);
+        }
 
         return $resource;
     }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

Selecting database zero is pointless (its already selected as default database), but adds extra TCP roundtrip and network load.

I doubt, if databases feature is widely used at all, considering Redis is a single-core application, and its databases are also not using parallelization. So probably in most cases the zero database is not just the default one, but the only one.